### PR TITLE
refactor(vscode-e2e)!: `launch` fixture

### DIFF
--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -13,18 +13,16 @@ It also includes `execute` utility to enable direct access to
 from your test code.
 
 ```ts
-import { expect, vi, beforeEach } from "vitest";
+import { expect } from "vitest";
 import { vscodeTest } from "@hiogawa/vscode-e2e/vitest";
 
-// Use task.meta for configuration
-beforeEach(({ task }) => {
-  task.meta.vscodeExtensionPath = "./";
-  task.meta.vscodeWorkspacePath = "./examples/basic";
-  task.meta.vscodeTrace = "on";
-});
+vscodeTest("example", async ({ launch }) => {
+  const { page, execute } = await launch({
+    extensionPath: "./",
+    workspacePage: "./examples/basic",
+    trace: "on",
+  });
 
-// `page` fixture to access window
-vscodeTest("example", async ({ page, execute }) => {
   // Open command pallete
   await page.keyboard.press("Control+Shift+P");
 
@@ -61,7 +59,7 @@ and record interactions and assertions.
 
 ![image](https://github.com/hi-ogawa/vscode-extension-shell-shortcut/assets/4232207/a508ddf1-4365-4743-8a59-73c62ca07c3d)
 
-Outside of Vitest, you can use `launchVscode` utility:
+Outside of Vitest, you can use `launch` utility directly:
 
 ```ts
 import { launch } from "@hiogawa/vscode-e2e";

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -53,6 +53,22 @@ vscodeTest("example", async ({ launch }) => {
 });
 ```
 
+You can also configure default settings via `VSCODE_E2E_...` environment variables:
+
+```ts
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    env: {
+      VSCODE_E2E_EXTENSION_PATH: "./",
+      VSCODE_E2E_WORKSPACE_PATH: "./examples/basic",
+      VSCODE_E2E_TRACE: "on",
+    },
+  },
+});
+```
+
 Like on Playwright, you can use [`page.pause()`](https://playwright.dev/docs/api/class-page#page-pause)
 to open [Playwright Inspector](https://playwright.dev/docs/debug#playwright-inspector)
 and record interactions and assertions.

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hiogawa/vscode-e2e",
-  "version": "0.0.1",
+  "version": "0.0.2-pre.0",
   "homepage": "https://github.com/hi-ogawa/vscode-extension-shell-shortcut/tree/main/packages/e2e",
   "repository": {
     "type": "git",

--- a/packages/e2e/src/vitest.ts
+++ b/packages/e2e/src/vitest.ts
@@ -2,7 +2,9 @@ import { launch } from "./utils";
 import { test, type TestAPI } from "vitest";
 import nodePath from "node:path";
 import type { ElectronApplication, Page } from "playwright";
-import type { ExecuteVscode } from ".";
+import type { ExecuteVscode } from "./proxy/client";
+import fs from "node:fs";
+import os from "node:os";
 
 export type VscodeTestFixture = {
   _launch: Awaited<ReturnType<typeof launch>>;
@@ -20,6 +22,84 @@ export interface VscodeTestTaskMeta {
 declare module "vitest" {
   interface TaskMeta extends VscodeTestTaskMeta {}
 }
+
+const defaultConfig = process.env as {
+  VSCODE_E2E_EXTENSION_PATH?: string;
+  VSCODE_E2E_WORKSPACE_PATH?: string;
+  VSCODE_E2E_TRACE?: "on" | "off";
+};
+
+type VscodeTestFixture2 = {
+  open: (options?: {
+    extensionPath?: string;
+    workspacePath?: string;
+    trace?: "on" | "off";
+  }) => Promise<{
+    app: ElectronApplication;
+    execute: ExecuteVscode;
+    page: Page;
+  }>;
+};
+
+export const vscodeTestV2: TestAPI<VscodeTestFixture2> =
+  test.extend<VscodeTestFixture2>({
+    open: async ({ task }, use) => {
+      const teardowns: (() => Promise<void>)[] = [];
+
+      await use(async (options) => {
+        const tempDir = await fs.promises.mkdtemp(
+          nodePath.join(os.tmpdir(), "vscode-e2e-"),
+        );
+
+        // launch
+        const { app, execute } = await launch({
+          extensionPath: defaultConfig.VSCODE_E2E_EXTENSION_PATH,
+          workspacePath: defaultConfig.VSCODE_E2E_WORKSPACE_PATH,
+          args: (args) => {
+            args.push(
+              `--extensions-dir=${nodePath.join(tempDir, "extensions")}`,
+              `--user-data-dir=${nodePath.join(tempDir, "user-data")}`,
+            );
+          },
+          ...options,
+        });
+        const page = await app.firstWindow();
+
+        // setup trace
+        const trace = options?.trace ?? defaultConfig.VSCODE_E2E_TRACE;
+        if (trace === "on") {
+          await page.context().tracing.start({
+            title: task.name,
+            screenshots: true,
+            snapshots: true,
+          });
+        }
+
+        // define teardown
+        teardowns.push(async () => {
+          if (trace === "on") {
+            await page.context().tracing.stop({
+              path: nodePath.resolve(
+                "test-results",
+                [nodePath.basename(task.file?.filepath!), task.name, task.id]
+                  .filter(Boolean)
+                  .join("-")
+                  .replaceAll(/\W/g, "-"),
+                "trace.zip",
+              ),
+            });
+          }
+          await app.close();
+          await fs.promises.rm(tempDir, { recursive: true, force: true });
+        });
+        return { app, execute, page };
+      });
+
+      for (const teardown of teardowns) {
+        await teardown();
+      }
+    },
+  });
 
 // cf. https://github.com/microsoft/playwright-vscode/blob/1c2f766a3ef4b7633fb19103a3d930ebe385250e/tests-integration/tests/baseTest.ts#L59
 export const vscodeTest: TestAPI<VscodeTestFixture> =

--- a/packages/e2e/src/vitest.ts
+++ b/packages/e2e/src/vitest.ts
@@ -24,6 +24,7 @@ declare module "vitest" {
 }
 
 const defaultConfig = process.env as {
+  VSCODE_E2E_DOWNLOAD_PATH?: string;
   VSCODE_E2E_EXTENSION_PATH?: string;
   VSCODE_E2E_WORKSPACE_PATH?: string;
   VSCODE_E2E_TRACE?: "on" | "off";
@@ -53,6 +54,7 @@ export const vscodeTestV2: TestAPI<VscodeTestFixture2> =
 
         // launch
         const { app, execute } = await launch({
+          vscodePath: defaultConfig.VSCODE_E2E_DOWNLOAD_PATH,
           extensionPath: defaultConfig.VSCODE_E2E_EXTENSION_PATH,
           workspacePath: defaultConfig.VSCODE_E2E_WORKSPACE_PATH,
           args: (args) => {

--- a/packages/e2e/src/vitest.ts
+++ b/packages/e2e/src/vitest.ts
@@ -28,6 +28,7 @@ type VscodeTestFixture = {
   }>;
 };
 
+// explicit typing for tsup dts
 export const vscodeTest: TestAPI<VscodeTestFixture> =
   test.extend<VscodeTestFixture>({
     launch: async ({ task }, use) => {

--- a/src/test-e2e/demo.test.ts
+++ b/src/test-e2e/demo.test.ts
@@ -1,8 +1,8 @@
 import { expect, vi } from "vitest";
-import { vscodeTestV2 as vscodeTest } from "@hiogawa/vscode-e2e/vitest";
+import { vscodeTest } from "@hiogawa/vscode-e2e/vitest";
 
-vscodeTest("demo", async ({ open }) => {
-  const { page, execute } = await open({
+vscodeTest("demo", async ({ launch }) => {
+  const { page, execute } = await launch({
     workspacePath: "./src/test/demo-workspace",
   });
 

--- a/src/test-e2e/demo.test.ts
+++ b/src/test-e2e/demo.test.ts
@@ -1,13 +1,11 @@
-import { expect, vi, beforeEach } from "vitest";
-import { vscodeTest } from "@hiogawa/vscode-e2e/vitest";
+import { expect, vi } from "vitest";
+import { vscodeTestV2 as vscodeTest } from "@hiogawa/vscode-e2e/vitest";
 
-beforeEach(({ task }) => {
-  task.meta.vscodeExtensionPath = "./";
-  task.meta.vscodeWorkspacePath = "./src/test/demo-workspace";
-  task.meta.vscodeTrace = "on";
-});
+vscodeTest("demo", async ({ open }) => {
+  const { page, execute } = await open({
+    workspacePath: "./src/test/demo-workspace",
+  });
 
-vscodeTest("demo", async ({ page, execute }) => {
   // open ex00.json
   await page.getByLabel("ex00.json", { exact: true }).locator("a").click();
 

--- a/src/test-e2e/example.test.ts
+++ b/src/test-e2e/example.test.ts
@@ -1,8 +1,8 @@
 import { expect } from "vitest";
-import { vscodeTestV2 as vscodeTest } from "@hiogawa/vscode-e2e/vitest";
+import { vscodeTest } from "@hiogawa/vscode-e2e/vitest";
 
-vscodeTest("example", async ({ open }) => {
-  const { page, execute } = await open();
+vscodeTest("example", async ({ launch }) => {
+  const { page, execute } = await launch();
 
   // Open command pallete
   await page.keyboard.press("Control+Shift+P");

--- a/src/test-e2e/example.test.ts
+++ b/src/test-e2e/example.test.ts
@@ -1,11 +1,9 @@
-import { expect, beforeEach } from "vitest";
-import { vscodeTest } from "@hiogawa/vscode-e2e/vitest";
+import { expect } from "vitest";
+import { vscodeTestV2 as vscodeTest } from "@hiogawa/vscode-e2e/vitest";
 
-beforeEach(({ task }) => {
-  task.meta.vscodeTrace = "on";
-});
+vscodeTest("example", async ({ open }) => {
+  const { page, execute } = await open();
 
-vscodeTest("example", async ({ page, execute }) => {
   // Open command pallete
   await page.keyboard.press("Control+Shift+P");
 

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitest/config";
+import { download } from "@vscode/test-electron";
 
 export default defineConfig({
   test: {
@@ -8,6 +9,7 @@ export default defineConfig({
     // it works but it's too heavy to run in parallel?
     fileParallelism: false,
     env: {
+      VSCODE_E2E_DOWNLOAD_PATH: await download(),
       VSCODE_E2E_EXTENSION_PATH: "./",
       VSCODE_E2E_TRACE: "on",
     },

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -5,7 +5,11 @@ export default defineConfig({
     dir: "./src/test-e2e",
     // Infinity on local for `page.pause()`
     testTimeout: process.env.CI ? 60_000 : Infinity,
-    // Need to separatee user-data-dir to launch multiple apps at the same time?
+    // it works but it's too heavy to run in parallel?
     fileParallelism: false,
+    env: {
+      VSCODE_E2E_EXTENSION_PATH: "./",
+      VSCODE_E2E_TRACE: "on",
+    },
   },
 });


### PR DESCRIPTION
Yet another alternative API. 

Such "higher order" fixture idea is again coming from playwright's `createTempDir` fixture:

https://github.com/microsoft/playwright-vscode/blob/1c2f766a3ef4b7633fb19103a3d930ebe385250e/tests-integration/tests/baseTest.ts#L87